### PR TITLE
Add EDLib as a FetchContent module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,43 @@
+build*
+
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Linker files
+*.ilk
+
+# Debugger Files
+*.pdb
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# debug information files
+*.dwo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,23 +6,22 @@ set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 set (CMAKE_CXX_STANDARD 11)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 find_package(ALPSCore COMPONENTS params hdf5 gf REQUIRED)
 find_package(ARPACK REQUIRED)
 find_package(BLAS)
 find_package(LAPACK)
 find_package(Eigen3 REQUIRED)
-
+include(EDLibDep)
 
 option(USE_MPI "Use MPI for ED" OFF)
 if(USE_MPI)
 find_package(MPI REQUIRED)
-endif(USE_MPI)
-find_package(EDLib REQUIRED)
-if(USE_MPI)
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_MPI")
 endif(USE_MPI)
-find_package(Eigen3 REQUIRED)
+
+add_edlib_dependency()
 
 set(extlibs
     ${Boost_LIBRARIES}
@@ -41,7 +40,6 @@ if(USE_MPI)
     ${MPI_Fortran_LIBRARIES}
     )
 endif(USE_MPI)
-    
 
 add_executable(ed_solver Anderson.cpp)
 

--- a/cmake/EDLibDep.cmake
+++ b/cmake/EDLibDep.cmake
@@ -4,7 +4,7 @@ function(add_edlib_dependency)
 
     FetchContent_Declare(
             EDLib
-            GIT_REPOSITORY https://github.com/gauravharhsa/EDLib.git
+            GIT_REPOSITORY https://github.com/gauravharsha/EDLib.git
             GIT_TAG origin/master # or a later release
             CMAKE_ARGS
                 -DARPACK_ROOT=${ARPACK_DIR}

--- a/cmake/EDLibDep.cmake
+++ b/cmake/EDLibDep.cmake
@@ -1,0 +1,14 @@
+
+function(add_edlib_dependency)
+    Include(FetchContent)
+
+    FetchContent_Declare(
+            EDLib
+            GIT_REPOSITORY https://github.com/gauravharhsa/EDLib.git
+            GIT_TAG origin/master # or a later release
+            CMAKE_ARGS
+                -DARPACK_ROOT=${ARPACK_DIR}
+    )
+
+    FetchContent_MakeAvailable(EDLib)
+endfunction()

--- a/cmake/EDLibDep.cmake
+++ b/cmake/EDLibDep.cmake
@@ -3,11 +3,11 @@ function(add_edlib_dependency)
     Include(FetchContent)
 
     FetchContent_Declare(
-            EDLib
-            GIT_REPOSITORY https://github.com/gauravharsha/EDLib.git
-            GIT_TAG origin/master # or a later release
-            CMAKE_ARGS
-                -DARPACK_ROOT=${ARPACK_DIR}
+        EDLib
+        GIT_REPOSITORY https://github.com/Green-Phys/EDLib.git
+        GIT_TAG origin/master # or a later release
+        CMAKE_ARGS
+            -DARPACK_ROOT=${ARPACK_DIR}
     )
 
     FetchContent_MakeAvailable(EDLib)


### PR DESCRIPTION
This PR achieves the following:

1. Reduces the number of external packages that the user needs to install for the SEET Code.
2. Automatically downloads and links the EDLib library for the Anderson impurity solver.
3. Enable simplified spack recipes.