### PR TITLE
Fix degenerate RHS in Sigma tail fit

### DIFF
--- a/Anderson.cpp
+++ b/Anderson.cpp
@@ -166,8 +166,8 @@ int main(int argc, const char ** argv) {
           for(size_t jo = 0, jor = 0; jo < nio; ++jo, jor += 2) {
             A << 1.0, iwn, iwn*iwn,  1.0, iwn1, iwn1*iwn1,  1.0, iwn2, iwn2*iwn2;
             B(0,0) = std::complex<double>(Sigma_ij(nw-1, is, io, jor), Sigma_ij(nw-1, is, io, jor + 1));
-            B(1,0) = std::complex<double>(Sigma_ij(nw-1, is, io, jor), Sigma_ij(nw-1, is, io, jor + 1));
-            B(2,0) = std::complex<double>(Sigma_ij(nw-1, is, io, jor), Sigma_ij(nw-1, is, io, jor + 1));
+            B(1,0) = std::complex<double>(Sigma_ij(nw-2, is, io, jor), Sigma_ij(nw-2, is, io, jor + 1));
+            B(2,0) = std::complex<double>(Sigma_ij(nw-3, is, io, jor), Sigma_ij(nw-3, is, io, jor + 1));
             MatrixXcd X = A.colPivHouseholderQr().solve(B).eval();
             Sigma_inf_ij(is, io, jo) = X(0,0).real();
             for(size_t iw = 0; iw < nw; ++iw) {


### PR DESCRIPTION
## Summary
- The 3-point high-frequency fit of $\Sigma(i\omega) = \Sigma_{\infty} + \frac{\Sigma_1}{i\omega} + \frac{\Sigma_2}{(i\omega)^2}$ in Anderson.cpp used $\Sigma(i\omega_{nw-1})$ for all three RHS rows, collapsing the linear system.
- Because the Vandermonde matrix A has $[1, 1, 1]^T$ as its first column, the solver returned $X = [\Sigma(i\omega_{nw-1}), 0, 0]^T$, so $\Sigma_{\infty}$ was approximated by $Re[\Sigma(i\omega_{nw-1})]$ with bias $\approx \frac{\Sigma_2}{\omega_{nw-1}^2}$—contaminating the static shift used downstream in Dyson's equation / chemical-potential alignment.
- Fix: Use the three distinct largest Matsubara points ($nw-1, nw-2, nw-3$), matching the working tail-fit in green-impurity/src/green/impurity/impurity_solver.h.

